### PR TITLE
Made it so pageTitle will only look for title in head tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = function(url, options){
 
   function parseHtml(html) {
     var $ = cheerio.load(html);
-    result.pageTitle = $('title').text();
+    result.pageTitle = $('head > title').text();
 
     $('[rel=stylesheet]').each(function() {
       var link = $(this).attr('href');


### PR DESCRIPTION
I filed an issue https://github.com/cssstats/cssstats/issues/159 and realized the issue was coming from the module in this repository.

    function parseHtml(html) {
        var $ = cheerio.load(html);
        result.pageTitle = $('title').text();

Inevitably, this would grab all `<title>` tags on the page. I made it so that it would only grab the `<title>` tag under `<head>`

Hope that works! :)