### PR TITLE
use only CSS content of linked files

### DIFF
--- a/utils/get-link-contents.js
+++ b/utils/get-link-contents.js
@@ -4,6 +4,12 @@ var request = require('request');
 module.exports = function getLinkContents(linkUrl, options) {
   var d = q.defer();
 
+  // expect linked css content
+  if (!/\.css$/i.test(linkUrl)) {
+    d.resolve('');
+    return d.promise;
+  }
+
   request({ url: linkUrl, timeout: options.timeout, gzip: true }, function(error, response, body) {
     if (error || response.statusCode !== 200) {
       d.reject(error);


### PR DESCRIPTION
As I were inspecting a website which uses a web-font referenced in their CSS I recognized that the module not only shows all linked files which are imported, but actually uses the content of them directly as the `result.css` is concatenated (including `.eot`). 

Saving bandwidth and preventing further errors as the content is used, the following update checks if the proper file extension of `.css` is used before doing a request. Existing applications which work so far shouldn't be affected, although it could be useful to rephrase the section on [cssstats](http://cssstats.com) from "CSS files scraped" into a more generic heading.

![cssstats-scraped-files](https://cloud.githubusercontent.com/assets/1060490/15504393/a4bd31f2-21b6-11e6-98d7-c04a75bdf9f9.png)
